### PR TITLE
Upodate syntax for ansible.builtin.import_tasks

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -5,16 +5,22 @@
 
   handlers:
     - name: Import handlers
-      ansible.builtin.import_tasks: handlers/main.yml
+      ansible.builtin.import_tasks:
+        file: handlers/main.yml
 
   tasks:
     - name: Install common system packages like htop, ncdu and vim
-      ansible.builtin.import_tasks: tasks/system_packages.yml
+      ansible.builtin.import_tasks:
+        file: tasks/system_packages.yml
     - name: Configure hostname to match inventory
-      ansible.builtin.import_tasks: tasks/hostname.yml
+      ansible.builtin.import_tasks:
+        file: tasks/hostname.yml
     - name: Set timezone according to iventory group
-      ansible.builtin.import_tasks: tasks/timezone.yml
+      ansible.builtin.import_tasks:
+        file: tasks/timezone.yml
     - name: Harden SSHD config against the scary internet
-      ansible.builtin.import_tasks: tasks/sshd_config.yml
+      ansible.builtin.import_tasks:
+        file: tasks/sshd_config.yml
     - name: Upload ssh_keys in files/ssh_keys/*.pub
-      ansible.builtin.import_tasks: tasks/ssh_keys.yml
+      ansible.builtin.import_tasks:
+        file: tasks/ssh_keys.yml


### PR DESCRIPTION
After some time, I wanted to go back into this project but had some trouble:

```
ERROR! this task 'ansible.builtin.import_tasks' has extra params, which is only allowed in the following modules: include_role, win_command, group_by, command, win_shell, import_tasks, script, shell, include, import_role, include_vars, raw, set_fact, include_tasks, add_host, meta

The error appears to be in '/home/vagrant/projects/ansible-base/main.yml': line 7, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  handlers:
    - name: Import handlers
      ^ here
```

Turns out, Ansible had some updates and now `ansible.buildin.import_tasks` requires a `file` parameter[^1]

[^1]: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/import_tasks_module.html#parameter-file